### PR TITLE
docs(sdk): rewrite README around BambuClient.connect

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -10,25 +10,85 @@ npm i @crazydev/bambu
 
 ## Cloud usage
 
+The recommended path is `BambuClient.connect()`. It handles the full auth
+lifecycle: load tokens from disk → login → trigger 2FA if needed → save tokens
+→ auto-refresh on 401.
+
 ```ts
-import { CloudClient } from "@crazydev/bambu";
+import { BambuClient, fileTokenStore } from "@crazydev/bambu";
+import { createInterface } from "node:readline/promises";
 
-const client = new CloudClient({ region: "EU" });
-
-const { requiresVerifyCode } = await client.loginWithPassword(
-  "you@example.com",
-  "password",
-);
-
-if (requiresVerifyCode) {
-  await client.sendVerifyCode("you@example.com");
-  // ... ask user for the code received by email
-  await client.loginWithCode("you@example.com", "123456");
-}
+const client = await BambuClient.connect({
+  email: process.env.BAMBU_EMAIL!,
+  password: process.env.BAMBU_PASSWORD!,
+  region: "EU",
+  tokenStore: fileTokenStore(".bambu-tokens.json"),
+  onVerifyCode: async () => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const code = (await rl.question("2FA code: ")).trim();
+    rl.close();
+    return code;
+  },
+});
 
 const devices = await client.devices();
-const status = await client.status();
+const printer = await client.getDeviceById("00M09B461100094");
+
+const statuses = await client.getDeviceStatuses();
+const status = await client.getDeviceStatusById("00M09B461100094");
+
 const tasks = await client.tasks(10);
+```
+
+### Token persistence
+
+A `tokenStore` is highly recommended — without it, users hit 2FA on every run.
+Built-in stores:
+
+```ts
+import { fileTokenStore, memoryTokenStore } from "@crazydev/bambu";
+
+fileTokenStore(".bambu-tokens.json"); // chmod 600 JSON file
+memoryTokenStore();                    // in-process (tests / short scripts)
+```
+
+`TokenStore` is a 3-method interface (`load` / `save` / `clear`) — implement
+your own to plug into a keychain, secrets manager, database, etc.
+
+### Auto-refresh
+
+When any authed call returns 401, the client transparently exchanges the
+`refreshToken` for a fresh access token, persists it via the store, and retries
+the request once. No user code involved.
+
+### Low-level auth (advanced)
+
+If you want to manage tokens yourself, use the static methods:
+
+```ts
+import { BambuClient } from "@crazydev/bambu";
+
+const result = await BambuClient.login("you@example.com", "password");
+let tokens;
+if (result.requiresVerifyCode) {
+  await BambuClient.sendVerifyCode("you@example.com");
+  tokens = await BambuClient.loginWithCode("you@example.com", "123456");
+} else {
+  tokens = result.tokens;
+}
+
+const fresh = await BambuClient.refreshTokens(tokens.refreshToken);
+
+const client = new BambuClient({ region: "EU", tokens });
+```
+
+### Status enums
+
+```ts
+import { PrintStatus, TaskStatus } from "@crazydev/bambu";
+
+if (device.print_status === PrintStatus.RUNNING) { /* ... */ }
+if (task.status === TaskStatus.FINISHED) { /* ... */ }
 ```
 
 ## LAN usage


### PR DESCRIPTION
## Summary

- Rewrites `packages/sdk/README.md` around the recommended `BambuClient.connect()` flow
- Documents `tokenStore` (`fileTokenStore` / `memoryTokenStore`), `onVerifyCode`, auto-refresh, low-level static auth methods, `getDeviceById` / `getDeviceStatuses` / `getDeviceStatusById`, `PrintStatus` / `TaskStatus` enums

Closes #1

## Test plan

- [ ] Render the README on GitHub and verify code blocks copy-paste cleanly
- [ ] Confirm the `BambuClient.connect()` snippet matches the example in `examples/cloud-test.ts`
