### PR TITLE
feat(sdk): add getTaskById(taskId)

### DIFF
--- a/packages/sdk/src/cloud/client.ts
+++ b/packages/sdk/src/cloud/client.ts
@@ -274,6 +274,22 @@ export class BambuClient {
   }
 
   /**
+   * Fetch a single print task by its id (iot-service variant).
+   *
+   * Complements {@link tasks} which only returns a paginated list. The response
+   * shape is undocumented in `api.yaml`, so it is returned as `unknown` until
+   * a real payload is captured.
+   *
+   * @example
+   * ```ts
+   * const task = await client.getTaskById("123456789");
+   * ```
+   */
+  async getTaskById(taskId: string): Promise<unknown> {
+    return this.authedRequest(`/iot-service/api/user/task/${encodeURIComponent(taskId)}`);
+  }
+
+  /**
    * Device task notification status (badge counts on print job updates).
    *
    * Response shape is undocumented — returned as `unknown`; callers should


### PR DESCRIPTION
## Summary
- Adds `BambuClient.getTaskById(taskId)` calling `GET /iot-service/api/user/task/{taskId}` via the existing `authedRequest` helper (auto-refresh on 401).
- Return type kept as `unknown` since `api.yaml` documents the response only as `type: object` — to be tightened once a real payload is captured on X1C/P1S.

## Test plan
- [x] `bun run --filter '@crazydev/bambu' build` passes
- [ ] Capture a real response on X1C and P1S, then type the return value in a follow-up

Closes #3