### PR TITLE
feat(sdk): add getPrintedPlates(instanceId)

### DIFF
--- a/packages/sdk/src/cloud/client.ts
+++ b/packages/sdk/src/cloud/client.ts
@@ -299,6 +299,18 @@ export class BambuClient {
     return this.authedRequest("/user-service/my/message/device/taskstatus");
   }
 
+  /**
+   * List which plates of a given model instance have already been printed.
+   *
+   * Response shape is not documented upstream — typed as `unknown` until a real
+   * payload is captured.
+   *
+   * @param instanceId Model instance id (integer, required).
+   */
+  async getPrintedPlates(instanceId: number): Promise<unknown> {
+    return this.authedRequest(`/user-service/my/task/printedplates?instanceId=${instanceId}`);
+  }
+
   /** Current tokens. Useful if you manage persistence yourself. */
   getTokens(): BambuTokens {
     return this.tokens;


### PR DESCRIPTION
## Summary
- Adds `getPrintedPlates(instanceId: number): Promise<unknown>` on `BambuClient`
- Wraps `GET /user-service/my/task/printedplates?instanceId={instanceId}` via the existing `authedRequest` helper
- Return type kept as `unknown` until a real response payload is captured (per issue note)

## Test plan
- [ ] `bun run --filter '@crazydev/bambu' build` passes
- [ ] Manual call against a known `instanceId` returns expected printed-plates payload

Closes #6