### PR TITLE
feat(sdk): add getMyTask(taskId)

### DIFF
--- a/packages/sdk/src/cloud/client.ts
+++ b/packages/sdk/src/cloud/client.ts
@@ -328,6 +328,23 @@ export class BambuClient {
     return this.authedRequest(`/user-service/my/task/printedplates?instanceId=${instanceId}`);
   }
 
+  /**
+   * Fetch a single task from the user-service by its `taskId`.
+   *
+   * Note: this is the `user-service` variant of get-task-by-id. The field set
+   * differs from the `iot-service` version — both endpoints expose different
+   * data and may coexist in the SDK. Response shape is not documented in
+   * `api.yaml`, hence the `unknown` return type.
+   *
+   * @example
+   * ```ts
+   * const task = await client.getMyTask("123456789");
+   * ```
+   */
+  async getMyTask(taskId: string): Promise<unknown> {
+    return this.authedRequest(`/user-service/my/task/${encodeURIComponent(taskId)}`);
+  }
+
   /** Current tokens. Useful if you manage persistence yourself. */
   getTokens(): BambuTokens {
     return this.tokens;


### PR DESCRIPTION
## Summary
- Adds `BambuClient.getMyTask(taskId)` calling `GET /user-service/my/task/{taskId}`.
- User-service variant of get-task-by-id; coexists with the iot-service variant (issue #3) since both expose different fields.
- Returns `unknown` for now — response shape is not documented in `api.yaml`, will be typed once a real response is captured.

## Test plan
- [ ] `bun run --filter '@crazydev/bambu' build` passes
- [ ] `bun run --filter '@crazydev/bambu' typecheck` passes
- [ ] Capture a real response on X1C / P1S and refine the return type in a follow-up

Closes #5
