### PR TITLE
feat(sdk): add listProjects()

### DIFF
--- a/packages/sdk/src/cloud/client.ts
+++ b/packages/sdk/src/cloud/client.ts
@@ -1,4 +1,4 @@
-import type { BambuDevice, BambuDeviceStatus, BambuStatusResponse, BambuTokens, PrintTask, Region } from "../types/index.js";
+import type { BambuDevice, BambuDeviceStatus, BambuProject, BambuStatusResponse, BambuTokens, PrintTask, Region } from "../types/index.js";
 import type { TokenStore } from "./token-store.js";
 
 const BASE_URLS: Record<Region, string> = {
@@ -282,6 +282,12 @@ export class BambuClient {
     return this.authedRequest(
       `/iot-service/api/user/device/version?dev_id=${encodeURIComponent(devId)}`,
     );
+  }
+
+  /** List all projects bound to the account. */
+  async listProjects(): Promise<BambuProject[]> {
+    const res = await this.authedRequest("/iot-service/api/user/project");
+    return res.projects ?? [];
   }
 
   /** Recent print tasks (most recent first). */

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -68,6 +68,13 @@ export interface BambuStatusResponse {
   devices: BambuDeviceStatus[];
 }
 
+export interface BambuProject {
+  project_id: string;
+  name: string;
+  status: string;
+  create_time: string;
+}
+
 export interface AmsDetailMapping {
   ams: number;
   sourceColor: string;


### PR DESCRIPTION
## Summary
- Add `listProjects()` method to `BambuClient` calling `GET /iot-service/api/user/project`
- Add `BambuProject` interface (`project_id`, `name`, `status`, `create_time`)

## Test plan
- [x] `bun run --filter '@crazydev/bambu' build` succeeds
- [ ] Manual call against a real account returns the expected projects array

Closes #7